### PR TITLE
Add an option to omit the personal spaces by default, because there are too much spaces.

### DIFF
--- a/ConfluenceSearch.py
+++ b/ConfluenceSearch.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python3
 """
-confluence_search_gui_faiss.py
-PyQt5 GUI for:
-  • Fetching a Confluence space
-  • (Optionally) embedding with Sentence-Transformers
-  • Building a FAISS IVF-HNSW index
-NEW:
-  • Right-hand log window (QTextEdit) so you don’t need the debug console
-  • Default values for URL, spaceKey, username, token
+Confluence semantic-search GUI (FAISS backend)
+
+• Spaces combo is filled from a local JSON cache at startup.
+• 'Load Spaces' refreshes the list from Confluence and rewrites the cache.
+• Personal spaces (~username) are omitted unless you tick
+  'Include personal spaces (~)'.
+• Log pane is cleared whenever an action button is pressed.
 """
 
-import os
-import sys
-import pickle
-import requests
+import json, os, sys, pickle, requests
+from pathlib import Path
 from requests.auth import HTTPBasicAuth
 from bs4 import BeautifulSoup
 import numpy as np
-
 from sentence_transformers import SentenceTransformer
 import faiss
 
@@ -28,34 +24,39 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt
 
+CACHE_FILE = Path("confluence_spaces.json")   # ----------
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Helpers
-# ──────────────────────────────────────────────────────────────────────────────
-def fetch_confluence_pages(base_url: str, space_key: str, auth) -> list:
-    """
-    Return list of tuples: (page_id, title, text)
-    """
+
+# ───────────────────────── helpers ───────────────────────────────────────────
+def fetch_spaces(base_url: str, auth) -> list:
+    """Return list[dict(key,name)] for all spaces."""
+    out, start, limit = [], 0, 50
+    url = f"{base_url.rstrip('/')}/rest/api/space"
+    while True:
+        r = requests.get(url, params={"limit": limit, "start": start}, auth=auth, timeout=30)
+        r.raise_for_status()
+        data = r.json()
+        out.extend({"key": s["key"], "name": s["name"]} for s in data.get("results", []))
+        if not data.get("_links", {}).get("next"):
+            break
+        start += limit
+    return out
+
+
+def fetch_pages(base_url: str, space_key: str, auth) -> list:
+    """Return list[(page_id, title, body_text)]."""
     pages, start, limit = [], 0, 50
     url = f"{base_url.rstrip('/')}/rest/api/content"
-
     while True:
-        params = {
-            "spaceKey": space_key,
-            "limit": limit,
-            "start": start,
-            "expand": "body.storage"
-        }
+        params = {"spaceKey": space_key, "limit": limit, "start": start, "expand": "body.storage"}
         r = requests.get(url, params=params, auth=auth, timeout=30)
         r.raise_for_status()
         data = r.json()
         items = data.get("results", [])
         if not items:
             break
-
         for p in items:
-            pid = p["id"]
-            title = p["title"]
+            pid, title = p["id"], p["title"]
             html = p["body"]["storage"]["value"]
             text = BeautifulSoup(html, "html.parser").get_text("\n").strip()
             pages.append((pid, title, text))
@@ -63,53 +64,56 @@ def fetch_confluence_pages(base_url: str, space_key: str, auth) -> list:
     return pages
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# GUI
-# ──────────────────────────────────────────────────────────────────────────────
-class ConfluenceSearchApp(QWidget):
-    # ────────────────────────────── UI ───────────────────────────────────────
+# ────────────────────────── main GUI class ───────────────────────────────────
+class ConfluenceSearch(QWidget):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Confluence Semantic Search (FAISS)")
-        self.resize(1100, 650)
+        self.resize(1180, 650)
 
         # runtime
         self.faiss_index = None
-        self.id_to_page = {}
-        self.model = None
+        self.id_to_page, self.model = {}, None
 
         self._build_ui()
+        self._load_spaces_cache()          # ← initial fill
 
+    # ───────────────── UI layout ─────────────────
     def _build_ui(self):
-        root = QHBoxLayout(self)                         # split: tabs | log
+        root = QHBoxLayout(self)           # split: tabs | log
         tabs = QTabWidget()
 
-        # ── Indexing tab ──────────────────────────────────────────────────
-        tab_index = QWidget()
-        form = QFormLayout()
+        # ------------- Indexing tab -------------
+        t_idx, form = QWidget(), QFormLayout()
 
-        # default values you requested
         self.base_url = QLineEdit("https://innovmetric.atlassian.net/wiki")
-        self.space_key = QLineEdit("Equipe4")
         self.username = QLineEdit(f"{os.getenv('USERNAME')}@innovmetric.com")
         self.api_token = QLineEdit(os.getenv("CONFLUENCE_TOKEN") or "")
         self.api_token.setEchoMode(QLineEdit.Password)
 
+        # Space selector + compact button
+        self.space_box = QComboBox()
+        btn_spaces = QPushButton("Load")          # small button
+        btn_spaces.setFixedWidth(100)
+        btn_spaces.clicked.connect(self.load_spaces)
+
+        h_space = QHBoxLayout(); h_space.addWidget(self.space_box); h_space.addWidget(btn_spaces)
+
+        # personal-space toggle
+        self.include_personal = QCheckBox("Include personal spaces (~)")
+        self.include_personal.setChecked(False)
+
         self.model_box = QComboBox()
-        self.model_box.addItems([
-            "all-MiniLM-L6-v2",
-            "all-mpnet-base-v2",
-            "paraphrase-albert-small-v2"
-        ])
+        self.model_box.addItems(["all-MiniLM-L6-v2",
+                                 "all-mpnet-base-v2",
+                                 "paraphrase-albert-small-v2"])
 
-        self.embed_title_body = QCheckBox("Embed title + body text")
-        self.embed_title_body.setChecked(False)              # per request
-
+        self.only_title  = QCheckBox("Just title")
+        self.only_title.setChecked(True)
         self.titles_only = QCheckBox("List titles only (skip embed/index)")
-        self.titles_only.setChecked(True)                    # per request
+        self.titles_only.setChecked(True)
 
-        # FAISS params
-        self.nlist = QSpinBox();  self.nlist.setRange(1, 4096); self.nlist.setValue(1)
+        self.nlist  = QSpinBox(); self.nlist.setRange(1, 4096); self.nlist.setValue(1)
         self.nprobe = QSpinBox(); self.nprobe.setRange(1, 64);  self.nprobe.setValue(1)
 
         btn_load  = QPushButton("Load Existing Index")
@@ -117,157 +121,172 @@ class ConfluenceSearchApp(QWidget):
         btn_load.clicked.connect(self.load_index)
         btn_build.clicked.connect(self.fetch_and_index)
 
-        self.progress = QProgressBar(); self.progress.setValue(0)
+        self.prog = QProgressBar(); self.prog.setValue(0)
 
-        form.addRow("Confluence base URL:", self.base_url)
-        form.addRow("Space key:",           self.space_key)
-        form.addRow("Username (email):",    self.username)
-        form.addRow("API token:",           self.api_token)
-        form.addRow("Embedding model:",     self.model_box)
-        form.addRow(self.embed_title_body)
+        form.addRow("Base URL:",        self.base_url)
+        form.addRow("Username:",        self.username)
+        form.addRow("API token:",       self.api_token)
+        form.addRow(QLabel("Space:"),   h_space)
+        form.addRow(self.include_personal)
+        form.addRow("Embedding model:", self.model_box)
+        form.addRow(self.only_title)
         form.addRow(self.titles_only)
-        form.addRow("FAISS nlist:",         self.nlist)
-        form.addRow("FAISS nprobe:",        self.nprobe)
+        form.addRow("FAISS nlist:",  self.nlist)
+        form.addRow("FAISS nprobe:", self.nprobe)
         form.addRow(btn_load, btn_build)
-        form.addRow("Progress:",            self.progress)
-        tab_index.setLayout(form)
+        form.addRow("Progress:", self.prog)
+        t_idx.setLayout(form)
 
-        # ── Search tab ─────────────────────────────────────────────────────
-        tab_search = QWidget()
-        sv = QVBoxLayout()
+        # ------------- Search tab --------------
+        t_search, sv = QWidget(), QVBoxLayout()
         hl = QHBoxLayout()
-        self.query = QLineEdit()
-        self.top_k = QSpinBox(); self.top_k.setRange(1, 100); self.top_k.setValue(5)
-        btn_search = QPushButton("Search")
-        btn_search.clicked.connect(self.do_search)
+        self.query = QLineEdit(); self.top_k = QSpinBox(); self.top_k.setRange(1, 100); self.top_k.setValue(5)
+        btn_search = QPushButton("Search"); btn_search.clicked.connect(self.do_search)
         hl.addWidget(QLabel("Query:")); hl.addWidget(self.query)
         hl.addWidget(QLabel("Top-k:")); hl.addWidget(self.top_k); hl.addWidget(btn_search)
         self.results = QTextEdit(); self.results.setReadOnly(True)
-        sv.addLayout(hl); sv.addWidget(self.results)
-        tab_search.setLayout(sv)
+        sv.addLayout(hl); sv.addWidget(self.results); t_search.setLayout(sv)
 
-        tabs.addTab(tab_index,  "Index / Fetch")
-        tabs.addTab(tab_search, "Search")
+        tabs.addTab(t_idx,    "Index / Fetch")
+        tabs.addTab(t_search, "Search")
 
-        # ── Log pane ───────────────────────────────────────────────────────
-        log_layout = QVBoxLayout()
-        log_label  = QLabel("Log")
-        self.log_widget = QTextEdit(); self.log_widget.setReadOnly(True)
-        log_layout.addWidget(log_label); log_layout.addWidget(self.log_widget)
+        # ------------- Log pane ---------------
+        log_box = QVBoxLayout()
+        log_box.addWidget(QLabel("Log"))
+        self.log = QTextEdit(); self.log.setReadOnly(True)
+        log_box.addWidget(self.log)
 
-        # assemble split view
         root.addWidget(tabs, stretch=3)
-        root.addLayout(log_layout, stretch=2)
+        root.addLayout(log_box, stretch=2)
 
-    # ────────────────────── utility: write to log pane ────────────────────
-    def log(self, msg: str):
-        self.log_widget.append(msg)
-        sys.stdout.write(msg + "\n")
-        sys.stdout.flush()
+    # ───────────── convenience ─────────────
+    def _clear_log(self):
+        self.log.clear()
 
-    # ────────────────────── lazy model loader ─────────────────────────────
+    def _log(self, msg: str):
+        self.log.append(msg); print(msg, flush=True)
+
     def _lazy_model(self):
         if self.model is None:
-            self.log(f"Loading model: {self.model_box.currentText()} …")
+            self._log(f"Loading model {self.model_box.currentText()} …")
             self.model = SentenceTransformer(self.model_box.currentText())
-            self.log("Model loaded.")
+            self._log("Model ready.")
         return self.model
 
-    # ────────────────────── menu actions ──────────────────────────────────
-    def load_index(self):
-        idx_path, _ = QFileDialog.getOpenFileName(self, "FAISS index (*.index)", "", "Index (*.index)")
-        map_path, _ = QFileDialog.getOpenFileName(self, "Page map (*.pkl)", "", "Pickle (*.pkl)")
-        if not idx_path or not map_path:
-            return
-        self.faiss_index = faiss.read_index(idx_path)
-        with open(map_path, "rb") as f:
-            self.id_to_page = pickle.load(f)
-        self.log(f"Loaded index with {len(self.id_to_page)} vectors.")
+    # ───────────── spaces cache ─────────────
+    def _load_spaces_cache(self):
+        if CACHE_FILE.exists():
+            try:
+                spaces = json.loads(CACHE_FILE.read_text())
+                self._fill_space_combo(spaces)
+                self._log(f"Loaded {len(spaces)} cached spaces.")
+            except Exception as e:
+                self._log(f"Cache read error: {e}")
 
-    def fetch_and_index(self):
-        self.progress.setValue(0)
-        self.log("Fetching pages …")
+    def _write_spaces_cache(self, spaces: list):
+        try:
+            CACHE_FILE.write_text(json.dumps(spaces, indent=2))
+            self._log(f"Saved {len(spaces)} spaces to cache.")
+        except Exception as e:
+            self._log(f"Cache write error: {e}")
+
+    def _fill_space_combo(self, spaces: list):
+        include_personal = self.include_personal.isChecked()
+        self.space_box.clear()
+        for s in spaces:
+            if not include_personal and s["key"].startswith("~"):
+                continue
+            self.space_box.addItem(f"{s['key']} — {s['name']}", userData=s["key"])
+        if self.space_box.count() == 0:
+            self.space_box.addItem("— no spaces —")
+
+    # ───────────── actions ─────────────
+    def load_spaces(self):
+        self._clear_log()
         auth = HTTPBasicAuth(self.username.text(), self.api_token.text())
         try:
-            pages = fetch_confluence_pages(self.base_url.text(), self.space_key.text(), auth)
+            spaces = fetch_spaces(self.base_url.text(), auth)
         except Exception as e:
-            QMessageBox.critical(self, "Error", f"Confluence fetch failed:\n{e}")
-            self.log(f"ERROR: {e}")
-            return
-        self.log(f"Fetched {len(pages)} pages.")
+            QMessageBox.critical(self, "Error", f"Could not list spaces:\n{e}")
+            self._log(f"ERROR: {e}"); return
+        self._fill_space_combo(spaces)
+        self._write_spaces_cache(spaces)
+        QMessageBox.information(self, "Spaces", f"{self.space_box.count()} spaces loaded.")
 
-        # ­­—— titles-only mode
+    def load_index(self):
+        self._clear_log()
+        idx_path, _ = QFileDialog.getOpenFileName(self, "FAISS index", "", "Index (*.index)")
+        map_path, _ = QFileDialog.getOpenFileName(self, "Page map", "", "Pickle (*.pkl)")
+        if not idx_path or not map_path: return
+        self.faiss_index = faiss.read_index(idx_path)
+        self.id_to_page  = pickle.load(open(map_path, "rb"))
+        self._log(f"Loaded index with {len(self.id_to_page)} vectors.")
+
+    # ───────────────── fetch & (optionally) index ─────────────────
+    def fetch_and_index(self):
+        self._clear_log()
+        self.prog.setValue(0)
+        auth = HTTPBasicAuth(self.username.text(), self.api_token.text())
+        space_key = self.space_box.currentData() or self.space_box.currentText().split(" — ")[0]
+        self._log(f"Fetching pages from space {space_key} …")
+
+        try:
+            pages = fetch_pages(self.base_url.text(), space_key, auth)
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Fetch failed:\n{e}")
+            self._log(f"ERROR: {e}"); return
+
+        self._log(f"{len(pages)} pages fetched.")
+
+        # titles-only debug
         if self.titles_only.isChecked():
-            self.log("=== Page titles ==================================")
-            for pid, title, _ in pages:
-                self.log(f"[{pid}] {title}")
-            self.log(f"=== {len(pages)} titles printed ==================\n")
-            QMessageBox.information(self, "Titles only", "Titles listed in log pane.")
-            return
+            for pid, title, _ in pages: self._log(f"[{pid}] {title}")
+            QMessageBox.information(self, "Done", "Titles listed in log pane."); return
 
-        # ­­—— embedding + FAISS
+        # ---- embeddings ----
         model = self._lazy_model()
-        texts = [
-            (f"{title}\n{text}" if self.embed_title_body.isChecked() else title)
-            for _, title, text in pages
-        ]
+        texts = [title if self.only_title.isChecked() else f"{title}\n{body}"
+                 for _, title, body in pages]
         dim = model.get_sentence_embedding_dimension()
 
-        self.log("Encoding …")
-        batch, vecs = 128, []
-        for i in range(0, len(texts), batch):
-            self.progress.setValue(int(i / len(texts) * 100))
-            QApplication.processEvents()
-            vecs.extend(model.encode(texts[i:i + batch], convert_to_numpy=True))
-        self.progress.setValue(100)
-        vecs = np.asarray(vecs, dtype="float32")
-        faiss.normalize_L2(vecs)
-        self.log("Building FAISS index …")
+        vecs = []
+        for i in range(0, len(texts), 128):
+            self.prog.setValue(int(i/len(texts)*100)); QApplication.processEvents()
+            vecs.extend(model.encode(texts[i:i+128], convert_to_numpy=True))
+        self.prog.setValue(100); vecs = np.asarray(vecs, dtype="float32"); faiss.normalize_L2(vecs)
 
-        nlist = self.nlist.value()
+        # ---- FAISS IVF-HNSW ----
+        self._log("Building FAISS index …")
         quantizer = faiss.IndexHNSWFlat(dim, 32)
-        index = faiss.IndexIVFFlat(quantizer, dim, nlist, faiss.METRIC_INNER_PRODUCT)
-        index.train(vecs)
-        index.add(vecs)
-        index.nprobe = self.nprobe.value()
-
+        index = faiss.IndexIVFFlat(quantizer, dim, self.nlist.value(), faiss.METRIC_INNER_PRODUCT)
+        index.train(vecs); index.add(vecs); index.nprobe = self.nprobe.value()
         faiss.write_index(index, "confluence_faiss.index")
-        with open("id_to_page.pkl", "wb") as f:
-            pickle.dump({i: (pid, title) for i, (pid, title, _) in enumerate(pages)}, f)
+        pickle.dump({i: (pid, title) for i, (pid,title,_) in enumerate(pages)},
+                    open("id_to_page.pkl","wb"))
 
         self.faiss_index = index
-        self.id_to_page = {i: (pid, title) for i, (pid, title, _) in enumerate(pages)}
-
-        self.log("Index built and saved (confluence_faiss.index).")
+        self.id_to_page  = {i: (pid, title) for i, (pid, title, _) in enumerate(pages)}
+        self._log("Index built and saved (confluence_faiss.index).")
         QMessageBox.information(self, "Done", f"Indexed {len(pages)} pages.")
 
+    # ───────────────── search ─────────────────
     def do_search(self):
         if not self.faiss_index:
-            QMessageBox.warning(self, "No index", "Load or build an index first.")
-            return
-        q = self.query.text()
-        if not q.strip():
-            return
-        self.log(f"Searching for: {q!r}")
-        model = self._lazy_model()
-        q_vec = model.encode([q], convert_to_numpy=True).astype("float32")
-        faiss.normalize_L2(q_vec)
-        dist, ids = self.faiss_index.search(q_vec, self.top_k.value())
+            QMessageBox.warning(self, "No index", "Load or build an index."); return
+        q = self.query.text().strip()
+        if not q: return
+        self._log(f"Query: {q!r}")
+        vec = self._lazy_model().encode([q], convert_to_numpy=True).astype("float32")
+        faiss.normalize_L2(vec)
+        dist, ids = self.faiss_index.search(vec, self.top_k.value())
         self.results.clear()
-        for rank, (idx, d) in enumerate(zip(ids[0], dist[0]), 1):
-            pid, title = self.id_to_page[int(idx)]
-            score = 1 - d
+        for rank,(idx,d) in enumerate(zip(ids[0],dist[0]),1):
+            pid, title = self.id_to_page[int(idx)]; score = 1 - d  # cosine sim
             self.results.append(f"{rank}. [{pid}] {title}  (sim={score:.3f})")
-        self.log("Search finished.")
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-def main() -> None:
-    app = QApplication(sys.argv)
-    w = ConfluenceSearchApp()
-    w.show()
-    sys.exit(app.exec_())
-
-
+# ──────────── entry point ────────────
 if __name__ == "__main__":
-    main()
+    app = QApplication(sys.argv)
+    win = ConfluenceSearch(); win.show()
+    sys.exit(app.exec_())


### PR DESCRIPTION
We add an option to omit the personal spaces by default, because there are too much spaces.

The spaces are serialized to file and are refreshed only on demand with the Load Spaces button, that is moved to the right of the Spaces combo.

Also, when Load Spaces, Load Existing Index, or Fetch Index are clicked, the log window is cleaned.